### PR TITLE
Update deps to new hapi scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Underdog brings [HTTP/2 server-push](http://httpwg.org/specs/rfc7540.html#PushRe
 ```js
 const Fs = require('fs');
 const Http2 = require('http2');
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 const Underdog = require('underdog');
 
 (async () => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Hoek = require('hoek');
+const Hoek = require('@hapi/hoek');
 const Stream = require('stream');
 const Package = require('../package');
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "lab -a code -t 100 -L",
+    "test": "lab -a @hapi/code -t 100 -L",
     "coveralls": "lab -r lcov | coveralls"
   },
   "repository": {
@@ -33,17 +33,17 @@
   },
   "homepage": "https://github.com/hapipal/underdog#readme",
   "dependencies": {
-    "hoek": "6.x.x"
+    "@hapi/hoek": "6.x.x"
   },
   "peerDependencies": {
-    "hapi": ">=18 <19"
+    "@hapi/hapi": ">=18 <19"
   },
   "devDependencies": {
-    "boom": "7.x.x",
-    "code": "5.x.x",
+    "@hapi/boom": "7.x.x",
+    "@hapi/code": "5.x.x",
+    "@hapi/hapi": "18.x.x",
+    "@hapi/lab": "19.x.x",
     "coveralls": "3.x.x",
-    "hapi": "18.x.x",
-    "lab": "18.x.x",
     "toys": ">=2.1.1 <3"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,7 @@ const Lab = require('@hapi/lab');
 const Code = require('@hapi/code');
 const Hapi = require('@hapi/hapi');
 const Boom = require('@hapi/boom');
+const Hoek = require('@hapi/hoek');
 const Toys = require('toys');
 const Http = require('http');
 const Https = require('https');
@@ -1238,7 +1239,7 @@ describe('Underdog', () => {
 
         // Consumes received data, required to trigger req stream's end
         // See: https://github.com/nodejs/help/issues/650
-        request.on('data', () => {});
+        request.on('data', Hoek.ignore);
 
         const [headers, [ignore, event]] = await Promise.all([ // eslint-disable-line no-unused-vars
             Toys.event(request, 'response'),

--- a/test/index.js
+++ b/test/index.js
@@ -2,10 +2,10 @@
 
 // Load modules
 
-const Lab = require('lab');
-const Code = require('code');
-const Hapi = require('hapi');
-const Boom = require('boom');
+const Lab = require('@hapi/lab');
+const Code = require('@hapi/code');
+const Hapi = require('@hapi/hapi');
+const Boom = require('@hapi/boom');
 const Toys = require('toys');
 const Http = require('http');
 const Https = require('https');
@@ -1230,15 +1230,18 @@ describe('Underdog', () => {
 
         flags.onCleanup = async () => {
 
-            client.destroy();
+            client.destroy(); // Alternatively, client.close()
             await server.stop();
         };
 
         const request = client.request({ ':path': '/' });
 
+        request.on('data', () => {});
+
         const [headers, [ignore, event]] = await Promise.all([ // eslint-disable-line no-unused-vars
             Toys.event(request, 'response'),
-            Toys.event(server.events, { name: 'request', channels: 'error' }, { error: false, multiple: true })
+            Toys.event(server.events, { name: 'request', channels: 'error' }, { error: false, multiple: true }),
+            Toys.event(request, 'end')
         ]);
 
         expect(headers[':status']).to.equal(500);

--- a/test/index.js
+++ b/test/index.js
@@ -1236,11 +1236,15 @@ describe('Underdog', () => {
 
         const request = client.request({ ':path': '/' });
 
+        // Consumes received data, required to trigger req stream's end
+        // See: https://github.com/nodejs/help/issues/650
         request.on('data', () => {});
 
         const [headers, [ignore, event]] = await Promise.all([ // eslint-disable-line no-unused-vars
             Toys.event(request, 'response'),
             Toys.event(server.events, { name: 'request', channels: 'error' }, { error: false, multiple: true }),
+            // Wait for end, so cleanup doesn't force close any connections,
+            // causing our test to fail w/ an ECONNRESET error
             Toys.event(request, 'end')
         ]);
 


### PR DESCRIPTION
Addresses #13 

@devinivy I added the odd new lines in the testing file to deal with that test failing on node 10 (v.10.15.3) and 12 (v.12.2.0).

The test would complete, all assertions would pass, but would then error out in the `onCleanup` callback with an `ECONNRESET` error. As far as I can tell, this happens because the http2 client's response stream hasn't closed, so calling `client.destroy()` force-ends that stream, triggering an `ECONNRESET`. Note that calling `client.close()`, the "graceful/clean" version of that call, closes the stream without error (though takes some extra time to complete).

The current approach ensures the response closes by consuming it via the data handler, which seems to enable the stream to end (without the data handler, the `Toys.event(request, 'end')` never fulfills, causing the test to timeout. I think? God, I dunno, very quickly got out of my depth.

My bad if I just made a mess of things here :trollface: 

